### PR TITLE
Optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ required-features = ["print_at_exit"]
 name = "bench"
 required-features = ["enable"]
 
+[[example]]
+name = "bench_single_thread"
+required-features = ["enable"]
+
 [dependencies]
 dashmap = { version = "4", optional = true }
 once_cell = { version = "1.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "countme"
 description = "Counts the number of live instances of types"
-version = "2.0.4"
+version = "3.0.0"
 categories = ["development-tools::profiling"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/countme"

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -62,7 +62,7 @@ fn main() {
 
     let bar = get::<Bar>();
     assert_eq!(bar.total, m * n);
-    assert!(bar.max_live >= n);
+    assert!(bar.max_live >= m);
     assert_eq!(bar.live, 0);
 
     println!("{:?}", t.elapsed());

--- a/examples/bench_single_thread.rs
+++ b/examples/bench_single_thread.rs
@@ -26,7 +26,7 @@ mod deeply {
 
 fn main() {
     countme::enable(true);
-    //let t = std::time::Instant::now();
+    let t = std::time::Instant::now();
     let n = 6;
     let m = 2_000_000;
 
@@ -73,5 +73,5 @@ fn main() {
     assert_eq!(bar.max_live, m + 1);
     assert_eq!(bar.live, 0);
 
-    //println!("{:?}", t.elapsed());
+    println!("{:?}", t.elapsed());
 }

--- a/examples/bench_single_thread.rs
+++ b/examples/bench_single_thread.rs
@@ -1,0 +1,77 @@
+use countme::{get, Count};
+
+#[derive(Default)]
+struct Foo {
+    _c: Count<Self>,
+}
+
+#[derive(Default)]
+struct Bar {
+    _c: Count<Self>,
+    _x: i32,
+}
+
+mod deeply {
+    pub(crate) mod nested {
+        pub(crate) mod module {
+            use countme::Count;
+
+            #[derive(Default)]
+            pub(crate) struct Quux {
+                _c: Count<Self>,
+            }
+        }
+    }
+}
+
+fn main() {
+    countme::enable(true);
+    //let t = std::time::Instant::now();
+    let n = 6;
+    let m = 2_000_000;
+
+    for _ in 0..n {
+        for _ in 0..m {
+            Foo::default();
+        }
+
+        let mut xs = Vec::with_capacity(m);
+        for _ in 0..m {
+            xs.push(Bar::default())
+        }
+
+        for _ in 0..m {
+            deeply::nested::module::Quux::default();
+        }
+
+        let fs = [
+            || drop(Foo::default()),
+            || drop(Bar::default()),
+            || drop(deeply::nested::module::Quux::default()),
+            || {
+                #[derive(Default)]
+                struct Local(Count<Self>);
+
+                Local::default();
+            },
+        ];
+        for i in 0..m {
+            fs[i % 4]();
+        }
+    }
+
+    let foo = get::<Foo>();
+    assert_eq!(foo.total, m * n + (m * n / 4));
+    assert_eq!(foo.max_live, 1);
+    assert_eq!(foo.live, 0);
+
+    let bar = get::<Bar>();
+    assert_eq!(bar.total, m * n + (m * n / 4));
+
+    // FIXME: why +1? This seems like a bug
+    // overreporting by 1 is not significant, but anyway
+    assert_eq!(bar.max_live, m + 1);
+    assert_eq!(bar.live, 0);
+
+    //println!("{:?}", t.elapsed());
+}

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -52,7 +52,9 @@ pub(crate) fn dec<T>() {
 }
 #[inline(never)]
 fn do_dec(key: &'static str) {
-    global_store().entry(&key).or_default().value().dec();
+    if let Some(store) = global_store().get(&key) {
+        store.value().dec();
+    }
 }
 
 #[inline]

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -65,7 +65,17 @@ pub(crate) fn inc<T: 'static>() {
 }
 #[inline(never)]
 fn do_inc(key: TypeId, name: &'static str) {
-    global_store().entry(key).or_insert_with(|| Store { name, ..Store::default() }).value().inc();
+    let global = global_store();
+
+    match global.get(&key) {
+        Some(store) => store.value().inc(),
+        None => global
+            .entry(key)
+            .or_insert_with(|| Store { name, ..Store::default() })
+            .downgrade()
+            .value()
+            .inc(),
+    }
 }
 
 pub(crate) fn get<T: 'static>() -> Counts {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,8 @@
 //! enabled anywhere in the crate graph.
 //!
 //! At run-time, the counters are controlled with [`enable`] function. Counting
-//! is disabled by default. Call `enable(true)` early in `main` to enable:
+//! is enabled by default if `print_at_exit` feature is enabled. Otherwise
+//! counting is disabled by default. Call `enable(true)` early in `main` to enable:
 //!
 //! ```rust
 //! fn main() {
@@ -105,7 +106,10 @@ impl<T: 'static> Drop for Count<T> {
 
 /// Enable or disable counting at runtime.
 ///
-/// Counting is enabled by default.
+/// Counting is enabled by default if `print_at_exit` feature is enabled.
+/// Otherwise counting is disabled by default.
+///
+/// If neither `enable` nor `print_at_exit` features are enabled, then this function is noop.
 pub fn enable(_yes: bool) {
     #[cfg(feature = "enable")]
     imp::enable(_yes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,25 +67,25 @@ pub struct Counts {
 
 /// Store this inside your struct as `_c: countme::Count<Self>`.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Count<T> {
+pub struct Count<T: 'static> {
     ghost: PhantomData<fn(T)>,
 }
 
-impl<T> Default for Count<T> {
+impl<T: 'static> Default for Count<T> {
     #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T> Clone for Count<T> {
+impl<T: 'static> Clone for Count<T> {
     #[inline]
     fn clone(&self) -> Self {
         Self::new()
     }
 }
 
-impl<T> Count<T> {
+impl<T: 'static> Count<T> {
     /// Create new `Count`, incrementing the corresponding count.
     #[inline]
     pub fn new() -> Count<T> {
@@ -95,7 +95,7 @@ impl<T> Count<T> {
     }
 }
 
-impl<T> Drop for Count<T> {
+impl<T: 'static> Drop for Count<T> {
     #[inline]
     fn drop(&mut self) {
         #[cfg(feature = "enable")]
@@ -113,7 +113,7 @@ pub fn enable(_yes: bool) {
 
 /// Returns the counts for the `T` type.
 #[inline]
-pub fn get<T>() -> Counts {
+pub fn get<T: 'static>() -> Counts {
     #[cfg(feature = "enable")]
     {
         return imp::get::<T>();


### PR DESCRIPTION
Hey there! I've watched your video in the "Explaining rust-analyzer" series where you said that this crate can be optimized and decided to look into it (great series btw, thanks :>).

I've implemented some general optimizations (mostly by looking for long functions in flamegraph) as well as the first approach from #9. I've tried to make commits self-contained and write good messages for them, so reviewing commit-by-commit is probably a good idea.

For me in the end, benchmarks (see details below) show these results:
- **2.6** times faster for single-thread
- **6.8** times faster for multi-thread

<details><summary>Details on how I've done benchmarking</summary>
<p>

That may be silly, but I've just run [hyperfine](https://github.com/sharkdp/hyperfine) on pairs of commits with a bash script like this (I'm bad at bash, I know):

```bash
#!/usr/bin/bash

if [ ! -z "$2" ]
then
  git checkout "$2" 2> /dev/null || echo "couldn't do checkout"
fi
echo "comparing:"
git log -1 --oneline

cargo br --example bench --features="enable" 2> /dev/null || echo "compilation failure"
cp ./target/release/examples/bench ./bench_current

if [ ! -z "$1" ]
then
  git checkout $1 2> /dev/null || echo "couldn't do checkout"
else
  git checkout HEAD~1 2> /dev/null || echo "couldn't do checkout"
fi
echo "to:"
git log -1 --oneline

cargo br --example bench --features="enable" 2> /dev/null || echo "compilation failure"
cp ./target/release/examples/bench ./bench_prev

git switch - 2> /dev/null || echo "couldn't switch back"

hyperfine -w 5 -m 20 -c "sleep 20" ./bench_prev ./bench_current
```

Results (multi-thread):
```text
comparing:
d76b8c3 (HEAD -> optimizations) Fix docs: correctly mention when counting is and isn't enabled by default
to:
b69e96e (HEAD) Disable at runtime by default
Benchmark 1: ./bench_prev
  Time (mean ± σ):      4.102 s ±  0.214 s    [User: 30.658 s, System: 0.021 s]
  Range (min … max):    3.660 s …  4.463 s    20 runs
 
Benchmark 2: ./bench_current
  Time (mean ± σ):     604.1 ms ±  48.3 ms    [User: 4363.1 ms, System: 10.3 ms]
  Range (min … max):   541.5 ms … 731.1 ms    20 runs
 
Summary
  './bench_current' ran
    6.79 ± 0.65 times faster than './bench_prev'
```

Results (single-thread):
```text
comparing:
d76b8c3 (HEAD -> optimizations) Fix docs: correctly mention when counting is and isn't enabled by default
to:
e95e4e4 (HEAD) Add single thread bench example
Benchmark 1: ./bench_prev
  Time (mean ± σ):      4.679 s ±  0.029 s    [User: 4.666 s, System: 0.007 s]
  Range (min … max):    4.626 s …  4.779 s    20 runs
 
Benchmark 2: ./bench_current
  Time (mean ± σ):      1.789 s ±  0.023 s    [User: 1.780 s, System: 0.006 s]
  Range (min … max):    1.775 s …  1.872 s    20 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  './bench_current' ran
    2.62 ± 0.04 times faster than './bench_prev'
```

</p>
</details>

I've also tried to see if running `RA_COUNT=1 cargo run -q --release -p rust-analyzer -- analysis-stats .` would be faster, but it seems like noise affects performance a lot more than couting.
