### PR TITLE
Bump deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "countme"
 description = "Counts the number of live instances of types"
-version = "3.0.0"
+version = "3.0.1"
 categories = ["development-tools::profiling"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/countme"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ name = "bench_single_thread"
 required-features = ["enable"]
 
 [dependencies]
-dashmap = { version = "4", optional = true }
+dashmap = { version = "5.0", optional = true }
 once_cell = { version = "1.5", optional = true }
 rustc-hash = { version = "1.1", optional = true }
 


### PR DESCRIPTION
This should let us avoid a duplicate dependency in `rust-analyzer`. `dashmap` doesn't seem to be used in the public API, so not counting it as a breaking change.