### PR TITLE
Bump dashmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ name = "bench_single_thread"
 required-features = ["enable"]
 
 [dependencies]
-dashmap = { version = "5.0", optional = true }
+dashmap = { version = "6.0", optional = true }
 once_cell = { version = "1.5", optional = true }
 rustc-hash = { version = "1.1", optional = true }
 


### PR DESCRIPTION
The new version has some performance improvements(https://github.com/xacrimon/dashmap/releases/tag/v6.0.0). Haven't performed any extensive benchmarks but running the `bench` example a few times shows ~10% improvement on my machine.